### PR TITLE
Fixes quip hanging

### DIFF
--- a/gaptrain/configurations.py
+++ b/gaptrain/configurations.py
@@ -614,14 +614,14 @@ class ConfigurationSet:
     def parallel_gap(self, gap, max_force=None):
         """Run single point or optimisation up to a F threshold using a GAP"""
         from gaptrain.calculators import run_gap
-        logger.warning('Not executing GAP parallel because of potential hang..')
+        logger.warning('Not executing GAP in parallel; potential hang')
 
         os.environ['OMP_NUM_THREADS'] = '1'
         os.environ['MLK_NUM_THREADS'] = '1'
         for config in self:
             config.run_gap(gap=gap, max_force=max_force, n_cores=4)
 
-        return
+        return None
 
     def parallel_dftb(self, max_force=None):
         """Run periodic DFTB+ on these configurations"""


### PR DESCRIPTION
QUIP can hang when being executed in parallel depending on the internal state of the code (e.g. if training has been run). I have no idea why this is but the 'fix'`` is just to execute calculations in serial if needs be. To maintain backwards compatibility I think we should leave the function definition as is, despite now not being what it does...